### PR TITLE
fix: 修复安装服务时配置路径的引号问题

### DIFF
--- a/src/views/config/index.vue
+++ b/src/views/config/index.vue
@@ -395,7 +395,7 @@ const installServiceHandle = async (row: any) => {
       return
     }
     const configPath = await join(await resourceDir(), CONFIG_PATH, row.fileName)
-    installServiceOnWindows(PREFIX_SVC + row.configFileName, '-c ' + configPath)
+    installServiceOnWindows(PREFIX_SVC + row.configFileName, '-c "' + configPath + '"')
       .then((res) => {
         info('服务安装:' + JSON.stringify(res))
         if (res) {


### PR DESCRIPTION
我遇到了与[[BUG]安装服务后服务无法正常启动](https://github.com/EasyTier/easytier-manager/issues/23)类似问题，经排查与服务启动参数中包含空格有关（而且默认安装目录似乎就是“Program Files”），在添加双引号后服务正常启动工作，于是我尝试在源码中也进行了添加