### PR TITLE
添加 Linux 编译支持

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+EasyTier Manager Pro — a Tauri 2 desktop app (Vue 3 frontend + Rust backend) for visually managing the EasyTier P2P networking kernel. Manages network configurations (TOML files), monitors node/peer status, and handles kernel lifecycle.
+
+## Common Commands
+
+### Development
+
+- `pnpm dev` — Vite dev server on port 4000
+- `pnpm td` — Tauri dev mode (frontend + Rust backend together)
+
+### Building
+
+- `pnpm build` — Production frontend build (mode: pro)
+- `pnpm tauri:build` — Full Tauri application build
+- Platform-specific: `pnpm build:win64`, `pnpm build:win32`, `pnpm build:winarm64`, `pnpm build:mac`, `pnpm build:linux`
+
+### Linting & Type Checking
+
+- `pnpm ts:check` — TypeScript type checking (vue-tsc)
+- `pnpm lint:eslint` — ESLint
+- `pnpm lint:format` — Prettier
+- `pnpm lint:style` — Stylelint
+- `pnpm cargo:fix` — Rust cargo fix
+
+### Other
+
+- `pnpm clean` — Remove node_modules
+- `pnpm clean:cache` — Clear build cache
+
+## Architecture
+
+### Frontend (`src/`)
+
+- **Vue 3 Composition API** with TypeScript, Element Plus UI, UnoCSS
+- **State**: Pinia stores in `src/store/modules/` — `easytier.ts` is the central store managing configs, running processes, kernel versions, STUN servers, and public peers. Persisted to localStorage.
+- **Router**: Hash-based (`createWebHashHistory`), 4 routes — Workplace (dashboard), Config, ConfigWeb, Setting
+- **Views**: `src/views/index/` (dashboard/monitoring), `src/views/config/` (network config CRUD), `src/views/configWeb/` (web management), `src/views/setting/` (app settings)
+- **Key utils**:
+  - `easyTierUtil.ts` — Parses CLI table output from EasyTier kernel (node info, peer info), extracts public IPs from logs
+  - `shellUtil.ts` — Shell command execution via Tauri, Windows service management
+  - `fileUtil.ts` — TOML config file operations via Tauri FS plugin
+  - `sysUtil.ts` — System-level utilities
+- **i18n**: English (`en.ts`) and Chinese (`zh-CN.ts`) in `src/locales/`
+- **Path alias**: `@/*` → `src/*`
+
+### Backend (`src-tauri/`)
+
+- **Rust/Tauri 2** with 4 IPC commands exposed to frontend:
+  - `run_cli(program, args)` — Execute CLI and return stdout
+  - `run_command(program, args)` — Spawn background process, return PID
+  - `get_exe_directory()` — Get application install directory
+  - `check_cold_start()` — Detect first launch vs window restore (uses tauri-plugin-store)
+- Windows-specific code uses `#[cfg(target_os = "windows")]` for `CREATE_NO_WINDOW` flag
+- Logging to `{exe_dir}/logs/` with fallback to console-only if directory creation fails
+- Production builds disable right-click menu and dev tools via `tauri-plugin-prevent-default`
+
+### Config Flow
+
+Network configurations are TOML files stored in the Tauri resource directory. The frontend reads/writes them via `tauri-plugin-fs`, parses with `smol-toml`, and launches EasyTier kernel processes via the `run_command` IPC. Running process PIDs are tracked in the `easytier` Pinia store and persisted to localStorage.
+
+## Key Conventions
+
+- Package manager: **pnpm** (>=8.1.0 required, `shamefully-hoist=true`)
+- Commit messages: Conventional Commits enforced by commitlint (types: feat, fix, docs, style, refactor, perf, test, ci, chore, revert, workflow, mod, wip, types, release)
+- Pre-commit: lint-staged via Husky
+- Node.js >=18.0.0, Rust >=1.92.0
+- Comments in source code are predominantly in Chinese
+- Environment configs: `.env.base`, `.env.dev`, `.env.test`, `.env.pro`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -955,6 +955,7 @@ name = "easytier-manager-pro"
 version = "3.2.7"
 dependencies = [
  "chrono",
+ "dirs",
  "log",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-shell = "2.3.4"
 tauri-plugin-prevent-default = "4"
 tauri-plugin-store = "2.3.0"
 chrono = "0.4.43"
+dirs = "6"
 
 # [profile.dev]
 # incremental = true # Compile your binary in smaller steps.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let mut attrs = tauri_build::Attributes::new();
+    let attrs = tauri_build::Attributes::new();
 
     #[cfg(target_os = "windows")]
     {

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,7 +1,11 @@
 fn main() {
-    let mut windows = tauri_build::WindowsAttributes::new();
-    windows = windows.app_manifest(
-        r#"
+    let mut attrs = tauri_build::Attributes::new();
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut windows = tauri_build::WindowsAttributes::new();
+        windows = windows.app_manifest(
+            r#"
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <dependency>
    <dependentAssembly>
@@ -24,8 +28,9 @@ fn main() {
   </trustInfo>
 </assembly>
 "#,
-    );
-    tauri_build::try_build(tauri_build::Attributes::new().windows_attributes(windows))
-        .expect("failed to run build script");
-    // tauri_build::build()
+        );
+        attrs = attrs.windows_attributes(windows);
+    }
+
+    tauri_build::try_build(attrs).expect("failed to run build script");
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -164,6 +164,56 @@
           "args": true,
           "cmd": "mstsc",
           "name": "mstsc"
+        },
+        {
+          "args": true,
+          "cmd": "sh",
+          "name": "sh"
+        },
+        {
+          "args": true,
+          "cmd": "systemctl",
+          "name": "systemctl"
+        },
+        {
+          "args": true,
+          "cmd": "launchctl",
+          "name": "launchctl"
+        },
+        {
+          "args": true,
+          "cmd": "ip",
+          "name": "ip"
+        },
+        {
+          "args": true,
+          "cmd": "ifconfig",
+          "name": "ifconfig"
+        },
+        {
+          "args": true,
+          "cmd": "whoami",
+          "name": "whoami"
+        },
+        {
+          "args": true,
+          "cmd": "xdg-open",
+          "name": "xdg-open"
+        },
+        {
+          "args": true,
+          "cmd": "open",
+          "name": "open"
+        },
+        {
+          "args": true,
+          "cmd": "xterm",
+          "name": "xterm"
+        },
+        {
+          "args": true,
+          "cmd": "xfreerdp",
+          "name": "xfreerdp"
         }
       ]
     },
@@ -209,6 +259,21 @@
           "args": true,
           "cmd": "mstsc",
           "name": "mstsc"
+        },
+        {
+          "args": true,
+          "cmd": "sh",
+          "name": "sh"
+        },
+        {
+          "args": true,
+          "cmd": "xterm",
+          "name": "xterm"
+        },
+        {
+          "args": true,
+          "cmd": "open",
+          "name": "open"
         }
       ]
     },

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -96,11 +96,31 @@
         {
           "args": true,
           "cmd": "$RESOURCE/resource/easytier-core",
-          "name": "easytier-core"
+          "name": "easytier-core-resource"
         },
         {
           "args": true,
           "cmd": "$RESOURCE/resource/easytier-cli",
+          "name": "easytier-cli-resource"
+        },
+        {
+          "args": true,
+          "cmd": "$APPDATA/resource/easytier-core",
+          "name": "easytier-core-appdata"
+        },
+        {
+          "args": true,
+          "cmd": "$APPDATA/resource/easytier-cli",
+          "name": "easytier-cli-appdata"
+        },
+        {
+          "args": true,
+          "cmd": "easytier-core",
+          "name": "easytier-core"
+        },
+        {
+          "args": true,
+          "cmd": "easytier-cli",
           "name": "easytier-cli"
         },
         {
@@ -226,11 +246,31 @@
         {
           "args": true,
           "cmd": "$RESOURCE/resource/easytier-core",
-          "name": "easytier-core"
+          "name": "easytier-core-resource"
         },
         {
           "args": true,
           "cmd": "$RESOURCE/resource/easytier-cli",
+          "name": "easytier-cli-resource"
+        },
+        {
+          "args": true,
+          "cmd": "$APPDATA/resource/easytier-core",
+          "name": "easytier-core-appdata"
+        },
+        {
+          "args": true,
+          "cmd": "$APPDATA/resource/easytier-cli",
+          "name": "easytier-cli-appdata"
+        },
+        {
+          "args": true,
+          "cmd": "easytier-core",
+          "name": "easytier-core"
+        },
+        {
+          "args": true,
+          "cmd": "easytier-cli",
           "name": "easytier-cli"
         },
         {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -42,6 +42,8 @@
     "fs:allow-resource-write-recursive",
     "fs:allow-app-read-recursive",
     "fs:allow-app-write-recursive",
+    "fs:allow-appdata-read-recursive",
+    "fs:allow-appdata-write-recursive",
     "log:default",
     "log:allow-log",
     "os:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -91,6 +91,16 @@
         {
           "args": true,
           "cmd": "$RESOURCE/resource/nssm",
+          "name": "nssm-resource"
+        },
+        {
+          "args": true,
+          "cmd": "$APPDATA/resource/nssm",
+          "name": "nssm-appdata"
+        },
+        {
+          "args": true,
+          "cmd": "nssm",
           "name": "nssm"
         },
         {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -41,6 +41,7 @@
     "fs:allow-resource-write",
     "fs:allow-resource-write-recursive",
     "fs:allow-app-read-recursive",
+    "fs:allow-app-write-recursive",
     "log:default",
     "log:allow-log",
     "os:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 use chrono::Local;
 use serde_json::json;
+#[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 use std::process::Command;
 use std::sync::Arc;
@@ -36,54 +37,69 @@ async fn check_cold_start(app: tauri::AppHandle) -> bool {
 
 #[tauri::command(rename_all = "snake_case")]
 fn run_cli(program: String, args: Vec<String>) -> String {
-    // CREATE_NO_WINDOW: 不创建控制台窗口
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
-    // DETACHED_PROCESS: 使进程在后台运行
-    // const DETACHED_PROCESS: u32 = 0x00000008;
     // 尝试执行命令并捕获输出
-    match Command::new(&program)
+    #[cfg(target_os = "windows")]
+    let result = {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        Command::new(&program)
+            .args(args)
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let result = Command::new(&program)
         .args(args)
-        .creation_flags(CREATE_NO_WINDOW)
-        .output() // 使用 output() 来获取输出
-    {
+        .output();
+
+    match result {
         Ok(output) => {
             // 将输出转换为字符串并返回
             match String::from_utf8(output.stdout) {
                 Ok(result) => result,
-                Err(e) => format!("Error decoding output: {}", e), // 返回解码错误信息
+                Err(e) => format!("Error decoding output: {}", e),
             }
         }
         Err(e) => {
             println!("Failed to execute process: {}", e);
-            return format!("Error: {}", e); // 返回错误信息
+            return format!("Error: {}", e);
         }
     }
 }
 
 #[tauri::command(rename_all = "snake_case")]
 fn run_command(program: String, args: Vec<String>) -> String {
-    // CREATE_NO_WINDOW: 不创建控制台窗口
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
-    // DETACHED_PROCESS: 使进程在后台运行
-    // const DETACHED_PROCESS: u32 = 0x00000008;
-
     // 尝试执行命令并捕获错误
-    match Command::new(&program)
+    #[cfg(target_os = "windows")]
+    let result = {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        Command::new(&program)
+            .args(args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let result = Command::new(&program)
         .args(args)
-        .stdout(std::process::Stdio::null()) // 将标准输出重定向到null
-        .stderr(std::process::Stdio::null()) // 将标准错误重定向到null
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn()
-    {
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+
+    match result {
         Ok(child) => {
-            let pid = child.id(); // 获取进程ID
-            return pid.to_string(); // 返回进程ID
+            let pid = child.id();
+            return pid.to_string();
         }
         Err(e) => {
             println!("Failed to execute process: {}", e);
-            return format!("Error: {}", e); // 返回错误信息
+            return format!("Error: {}", e);
         }
-    };
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,9 +118,19 @@ fn get_exe_directory() -> String {
     }
 }
 
-// 获取日志目录（程序安装目录下的 logs）
+// 获取日志目录（优先程序安装目录下的 logs，只读环境回退到用户数据目录）
 fn get_log_directory() -> String {
-    format!("{}/logs", get_exe_directory())
+    let exe_log_dir = format!("{}/logs", get_exe_directory());
+    if std::fs::create_dir_all(&exe_log_dir).is_ok() {
+        return exe_log_dir;
+    }
+    if let Some(data_dir) = dirs::data_dir() {
+        let app_log_dir = data_dir.join("easytier-manager-pro").join("logs");
+        if std::fs::create_dir_all(&app_log_dir).is_ok() {
+            return app_log_dir.display().to_string();
+        }
+    }
+    exe_log_dir
 }
 
 fn show_window(app: &AppHandle) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@ import { useDesign } from '@/hooks/web/useDesign'
 import { useAppStore } from '@/store/modules/app'
 import { useEasyTierStore } from '@/store/modules/easytier'
 import { useTrayStore } from '@/store/modules/trayStore'
-import { checkDir } from '@/utils/fileUtil'
+import { checkDir, initDataDir, migrateDataIfNeeded } from '@/utils/fileUtil'
 import { restoreStateCurrent, StateFlags } from '@tauri-apps/plugin-window-state'
 import { computed, onBeforeMount, onMounted, ref } from 'vue'
 
@@ -37,6 +37,8 @@ onBeforeMount(async () => {
   appStore.initTheme()
   trayStore.initTray()
   restoreStateCurrent(StateFlags.ALL)
+  await initDataDir()
+  await migrateDataIfNeeded()
   checkDir()
   easytierStore.setConfigPath()
 })

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -679,7 +679,7 @@ export default {
     // Service management settings
     serviceManagementSettings: 'Service Management Settings',
     serviceInstallMethod: 'Service Install Method',
-    installMethodNssm: 'NSSM (Better Compatibility)',
+    installMethodNative: 'Native (NSSM/systemd/launchd)',
     installMethodOfficial: 'Official easytier-cli (v1.2.0+)',
     serviceDisplayName: 'Service Display Name',
     serviceDescription: 'Service Description',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -680,7 +680,7 @@ export default {
     // 服务管理设置
     serviceManagementSettings: '服务管理设置',
     serviceInstallMethod: '服务安装方式',
-    installMethodNssm: 'NSSM (推荐，兼容性好)',
+    installMethodNative: '原生方式 (NSSM/systemd/launchd)',
     installMethodOfficial: '官方 easytier-cli (v2.0+)',
     serviceDisplayName: '服务显示名称',
     serviceDescription: '服务描述',

--- a/src/store/modules/easytier.ts
+++ b/src/store/modules/easytier.ts
@@ -8,8 +8,8 @@ import {
   USER_AGENT
 } from '@/constants/easytier'
 import { listTomlFiles } from '@/utils/fileUtil'
+import { getDataDir } from '@/utils/fileUtil'
 import { startServiceNative } from '@/utils/shellUtil'
-import { resourceDir } from '@tauri-apps/api/path'
 import { fetch } from '@tauri-apps/plugin-http'
 import dayjs from 'dayjs'
 import { defineStore } from 'pinia'
@@ -158,7 +158,7 @@ export const useEasyTierStore = defineStore(
       //   return
       // }
       // 如果 configJsonObj 中存在 path 键，则设置 configPath 为 path 键的值，如果不存在则判断 path 是否为空，为空则设置为 resource 目录，否则设置为 path 键的值
-      configPath.value = await resourceDir()
+      configPath.value = getDataDir()
       // configJsonObj.configPath = RESOURCE_PATH
       // await writeConfigJsonObj(configJsonObj)
     }

--- a/src/store/modules/easytier.ts
+++ b/src/store/modules/easytier.ts
@@ -8,7 +8,7 @@ import {
   USER_AGENT
 } from '@/constants/easytier'
 import { listTomlFiles } from '@/utils/fileUtil'
-import { startServiceOnWindows } from '@/utils/shellUtil'
+import { startServiceNative } from '@/utils/shellUtil'
 import { resourceDir } from '@tauri-apps/api/path'
 import { fetch } from '@tauri-apps/plugin-http'
 import dayjs from 'dayjs'
@@ -60,7 +60,7 @@ export const useEasyTierStore = defineStore(
     // 当前选择的列（存储prop值）
     const selectedColumns = ref(['rx_bytes', 'tx_bytes', 'nat_type'])
     // 默认服务安装方式
-    const defaultServiceInstallMethod = ref<'nssm' | 'official'>('nssm')
+    const defaultServiceInstallMethod = ref<'native' | 'official'>('native')
     // 默认开机自启动
     const defaultEnableAutostart = ref(true)
     const setConfigList = (list) => {
@@ -322,7 +322,7 @@ export const useEasyTierStore = defineStore(
     const setSelectedColumns = (list) => {
       selectedColumns.value = list
     }
-    const setDefaultServiceInstallMethod = (method: 'nssm' | 'official') => {
+    const setDefaultServiceInstallMethod = (method: 'native' | 'official') => {
       defaultServiceInstallMethod.value = method
     }
     const setDefaultEnableAutostart = (enable: boolean) => {
@@ -334,7 +334,7 @@ export const useEasyTierStore = defineStore(
         const fileList = await listTomlFiles()
         for (const f of fileList) {
           const configName = f.replace('.toml', '')
-          await startServiceOnWindows(PREFIX_SVC + configName)
+          await startServiceNative(PREFIX_SVC + configName)
         }
       }
     }

--- a/src/types/easyTier.ts
+++ b/src/types/easyTier.ts
@@ -124,7 +124,7 @@ interface RunningItem {
   fileName?: string
   pid?: number
   serviceStatus?: string
-  installMethod?: 'nssm' | 'official' | 'none' // 服务安装方式
+  installMethod?: 'native' | 'official' | 'none' // 服务安装方式
 }
 
 interface RunningWebItem {

--- a/src/types/formTypes.ts
+++ b/src/types/formTypes.ts
@@ -100,7 +100,7 @@ export interface FormWebData {
 
 // 服务安装配置
 export interface ServiceInstallConfig {
-  installMethod: 'nssm' | 'official' // 安装方式
+  installMethod: 'native' | 'official' // 安装方式: native=NSSM(Win)/systemd(Linux)/launchd(macOS)
   description?: string // 服务描述
   displayName?: string // 显示名称
   enableAutostart: boolean // 是否开机自启

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -1,7 +1,7 @@
 import { CONFIG_PATH, LOG_PATH, RESOURCE_PATH, USER_AGENT } from '@/constants/easytier'
 // import { useI18n } from '@/hooks/web/useI18n'
 import { t } from '@/utils/i18nUtil'
-import { dirname, extname, join, resourceDir } from '@tauri-apps/api/path'
+import { appDataDir, dirname, extname, join, resourceDir } from '@tauri-apps/api/path'
 import {
   BaseDirectory,
   exists,
@@ -14,8 +14,9 @@ import {
   writeTextFile
 } from '@tauri-apps/plugin-fs'
 import { fetch } from '@tauri-apps/plugin-http'
-import { attachConsole, error, info } from '@tauri-apps/plugin-log'
+import { attachConsole, error, info, warn } from '@tauri-apps/plugin-log'
 import { open } from '@tauri-apps/plugin-shell'
+import { Command } from '@tauri-apps/plugin-shell'
 import { ElNotification } from 'element-plus'
 import { unzipSync } from 'fflate'
 import pkg from '../../package.json'
@@ -25,6 +26,145 @@ import dayjs from 'dayjs'
 attachConsole()
 // ts文件无法直接使用useI18n，所以使用t函数
 // const { t } = useI18n()
+
+// ==================== 数据目录解析器 ====================
+// 解决只读安装环境（Nix store、Flatpak、系统包）下 resourceDir 不可写的问题
+
+let resolvedDataDir: string | null = null
+let useAppData = false
+
+/**
+ * 初始化数据目录：检测 resourceDir 是否可写，不可写则回退到 appDataDir
+ * 必须在应用启动时、任何文件操作之前调用
+ */
+export async function initDataDir(): Promise<void> {
+  try {
+    const testFile = '.write_test_' + Date.now()
+    try {
+      await writeTextFile(testFile, 'test', { baseDir: BaseDirectory.Resource })
+      await remove(testFile, { baseDir: BaseDirectory.Resource })
+      // resourceDir 可写，使用它
+      resolvedDataDir = await resourceDir()
+      useAppData = false
+      info(`数据目录: ${resolvedDataDir} (resourceDir, 可写)`)
+    } catch {
+      // resourceDir 不可写，回退到 appDataDir
+      useAppData = true
+      resolvedDataDir = await appDataDir()
+      // 确保 appDataDir 存在
+      try {
+        const appDirExists = await exists('', { baseDir: BaseDirectory.AppData })
+        if (!appDirExists) {
+          await mkdir('', { baseDir: BaseDirectory.AppData, recursive: true })
+        }
+      } catch {
+        // appDataDir 通常由系统自动创建
+      }
+      info(`数据目录: ${resolvedDataDir} (appDataDir, resourceDir 只读)`)
+    }
+  } catch (e: any) {
+    error(`初始化数据目录失败: ${JSON.stringify(e)}`)
+    // 最终回退：使用 resourceDir
+    resolvedDataDir = await resourceDir()
+    useAppData = false
+  }
+}
+
+/**
+ * 获取已解析的数据目录路径（同步，initDataDir 之后调用）
+ */
+export function getDataDir(): string {
+  if (!resolvedDataDir) {
+    warn('getDataDir() 在 initDataDir() 之前调用，返回空字符串')
+    return ''
+  }
+  return resolvedDataDir
+}
+
+/**
+ * 获取当前应使用的 BaseDirectory
+ */
+export function getBaseDirectory(): BaseDirectory {
+  return useAppData ? BaseDirectory.AppData : BaseDirectory.Resource
+}
+
+/**
+ * 一次性迁移：将 resourceDir 下的 config/、resource/、logs/ 复制到 appDataDir
+ * 仅在 useAppData=true 时执行，使用 .migrated 标记避免重复
+ */
+export async function migrateDataIfNeeded(): Promise<void> {
+  if (!useAppData) return
+
+  try {
+    const markerExists = await exists('.migrated', { baseDir: BaseDirectory.AppData })
+    if (markerExists) return
+
+    info('开始从 resourceDir 迁移数据到 appDataDir...')
+    const dirsToMigrate = [CONFIG_PATH, RESOURCE_PATH, LOG_PATH]
+
+    for (const dir of dirsToMigrate) {
+      try {
+        const srcExists = await exists(dir, { baseDir: BaseDirectory.Resource })
+        if (!srcExists) continue
+
+        // 确保目标目录存在
+        const destExists = await exists(dir, { baseDir: BaseDirectory.AppData })
+        if (!destExists) {
+          await mkdir(dir, { baseDir: BaseDirectory.AppData, recursive: true })
+        }
+
+        // 读取源目录文件列表
+        const entries = await readDir(dir, { baseDir: BaseDirectory.Resource })
+        for (const entry of entries) {
+          try {
+            if (entry.isDirectory) continue
+            const filePath = await join(dir, entry.name)
+            const content = await readFile(filePath, { baseDir: BaseDirectory.Resource })
+            await writeFile(filePath, content, { baseDir: BaseDirectory.AppData })
+          } catch (e: any) {
+            warn(`迁移文件 ${entry.name} 失败: ${JSON.stringify(e)}`)
+          }
+        }
+        info(`迁移目录 ${dir} 完成`)
+      } catch (e: any) {
+        warn(`迁移目录 ${dir} 失败: ${JSON.stringify(e)}`)
+      }
+    }
+
+    // 在 Linux/macOS 上为迁移的二进制文件添加可执行权限
+    try {
+      const { platform } = await import('@tauri-apps/plugin-os')
+      const os = platform()
+      if (os === 'linux' || os === 'macos') {
+        const appDir = await appDataDir()
+        const binaries = ['easytier-core', 'easytier-cli']
+        for (const bin of binaries) {
+          try {
+            const binPath = await join(appDir, RESOURCE_PATH, bin)
+            const binExists = await exists(await join(RESOURCE_PATH, bin), {
+              baseDir: BaseDirectory.AppData
+            })
+            if (binExists) {
+              await Command.create('sh', ['-c', `chmod +x "${binPath}"`]).execute()
+            }
+          } catch {
+            // 忽略 chmod 失败
+          }
+        }
+      }
+    } catch {
+      // 忽略平台检测失败
+    }
+
+    // 写入迁移标记
+    await writeTextFile('.migrated', new Date().toISOString(), {
+      baseDir: BaseDirectory.AppData
+    })
+    info('数据迁移完成')
+  } catch (e: any) {
+    error(`数据迁移失败: ${JSON.stringify(e)}`)
+  }
+}
 
 // 程序启动时，判断是否存在resource目录，不存在则创建
 export const checkDir = async (dirPath: string = RESOURCE_PATH) => {
@@ -36,9 +176,10 @@ export const checkDir = async (dirPath: string = RESOURCE_PATH) => {
     } catch (_error) {
       /* empty */
     }
-    const dirExists = await exists(dirPath, { baseDir: BaseDirectory.Resource })
+    const baseDir = getBaseDirectory()
+    const dirExists = await exists(dirPath, { baseDir })
     if (!dirExists) {
-      await mkdir(dirPath, { baseDir: BaseDirectory.Resource, recursive: true })
+      await mkdir(dirPath, { baseDir, recursive: true })
     }
   } catch (e: any) {
     error(`创建resource目录时出错:${JSON.stringify(e)}`)
@@ -48,29 +189,30 @@ export const checkDir = async (dirPath: string = RESOURCE_PATH) => {
 
 // 检测文件是否存在，不存在则创建空文件
 export const fileExist = async (filePath: string) => {
-  const exist = await exists(filePath, { baseDir: BaseDirectory.Resource })
+  const baseDir = getBaseDirectory()
+  const exist = await exists(filePath, { baseDir })
   if (!exist) {
-    await writeFileContent(filePath, '', { baseDir: BaseDirectory.Resource })
+    await writeFileContent(filePath, '', { baseDir })
   }
   return exist
 }
 // 获取resource目录，如果resource目录不存在，则调用checkResourceDir创建，最终返回带'resource'后缀的目录
 export const getResourceDir = async () => {
   await checkDir()
-  return await join(await resourceDir(), RESOURCE_PATH)
+  return await join(getDataDir(), RESOURCE_PATH)
 }
 export const getCliDir = async () => {
   await checkDir()
-  return await join(await resourceDir(), RESOURCE_PATH, 'easytier-cli')
+  return await join(getDataDir(), RESOURCE_PATH, 'easytier-cli')
 }
 export const getCoreDir = async () => {
   await checkDir()
-  return await join(await resourceDir(), RESOURCE_PATH, 'easytier-core')
+  return await join(getDataDir(), RESOURCE_PATH, 'easytier-core')
 }
 // 获取resource下的logs目录
 export const getLogsDir = async () => {
   await checkDir(LOG_PATH)
-  return await join(await resourceDir(), LOG_PATH)
+  return await join(getDataDir(), LOG_PATH)
 }
 // 获取 config目录， RESOURCE_PATH+CONFIG_PATH
 // export const getConfigPath = async () => {
@@ -113,7 +255,7 @@ export async function writeFileContent(
   }
 ): Promise<void> {
   try {
-    const finalOptions = { baseDir: BaseDirectory.Resource, append: false, ...options }
+    const finalOptions = { baseDir: getBaseDirectory(), append: false, ...options }
     await checkDir(filePath)
     if (typeof content === 'string') {
       // 使用 writeTextFile 处理字符串内容
@@ -156,7 +298,7 @@ export async function readFileContent(
   }
 ): Promise<string | Uint8Array> {
   try {
-    const { baseDir = BaseDirectory.Resource, asBinary = false } = options || {}
+    const { baseDir = getBaseDirectory(), asBinary = false } = options || {}
     await checkDir(filePath)
     if (asBinary) {
       const content = await readFile(filePath, { baseDir })
@@ -181,7 +323,7 @@ export async function readFileContent(
 export const listFiles = async (targetDir: string = RESOURCE_PATH) => {
   try {
     await checkDir(targetDir)
-    const entries = await readDir(targetDir, { baseDir: BaseDirectory.Resource })
+    const entries = await readDir(targetDir, { baseDir: getBaseDirectory() })
     return entries.map((entry) => entry.name)
   } catch (e: any) {
     error(`Error listing resource files:${JSON.stringify(e)}`)
@@ -195,7 +337,7 @@ export const listTomlFiles = async (targetDir: string = CONFIG_PATH) => {
     // @ts-ignore
     const _ = await checkDir(targetDir)
 
-    const entries = await readDir(targetDir, { baseDir: BaseDirectory.Resource })
+    const entries = await readDir(targetDir, { baseDir: getBaseDirectory() })
     return entries.filter((entry) => entry.name.endsWith('.toml')).map((entry) => entry.name)
   } catch (e: any) {
     error(`Error listing resource files:${JSON.stringify(e)}`)
@@ -208,7 +350,7 @@ export const writeConfigJsonObj = async (obj: any) => {
   const configJsonPath = await join(RESOURCE_PATH, 'config.json')
   await checkDir(configJsonPath)
   await writeFileContent(configJsonPath, JSON.stringify(obj), {
-    baseDir: BaseDirectory.Resource
+    baseDir: getBaseDirectory()
   })
 }
 
@@ -218,7 +360,7 @@ export const getConfigJsonObj = async () => {
     const configJsonPath = await join(RESOURCE_PATH, 'config.json')
     await checkDir(configJsonPath)
     const configJson = await readFileContent(configJsonPath, {
-      baseDir: BaseDirectory.Resource
+      baseDir: getBaseDirectory()
     })
     return JSON.parse(configJson as string)
   } catch (e: any) {
@@ -233,7 +375,7 @@ export const getConfigJsonObj = async () => {
  * @param path 路径
  */
 export const deleteFileOrDir = async (path: string) => {
-  await remove(path, { baseDir: BaseDirectory.Resource, recursive: true })
+  await remove(path, { baseDir: getBaseDirectory(), recursive: true })
 }
 
 /**
@@ -293,7 +435,7 @@ export async function downloadFile(fileUrl: string): Promise<boolean> {
 
     // 写入文件
     await writeFileContent(savePath, uint8Array, {
-      baseDir: BaseDirectory.Resource
+      baseDir: getBaseDirectory()
     })
 
     ElNotification({
@@ -341,7 +483,7 @@ export async function extractFile(
   try {
     // 读取zip文件内容  resource\easytier-windows-x86_64-v2.0.3.zip
     const zipContent = (await readFileContent(zipPath, {
-      baseDir: BaseDirectory.Resource,
+      baseDir: getBaseDirectory(),
       asBinary: true
     })) as Uint8Array
 
@@ -373,7 +515,7 @@ export async function extractFile(
 
         // 写入文件
         await writeFileContent(targetPath, fileData, {
-          baseDir: BaseDirectory.Resource
+          baseDir: getBaseDirectory()
         })
       } catch (e: any) {
         error(`处理文件 ${filePath} 时出错:${JSON.stringify(e)}`)
@@ -436,7 +578,7 @@ export const clearLogs = async () => {
   try {
     const logsFile = await join('logs', pkg.name + '.log')
     // 清空 logsFile 的内容（如果失败不影响程序启动）
-    await writeFileContent(logsFile, '', { baseDir: BaseDirectory.Resource })
+    await writeFileContent(logsFile, '', { baseDir: getBaseDirectory() })
   } catch (e: any) {
     // 如果清理失败，只记录警告，不阻塞启动
     console.warn(`清理日志文件失败（不影响使用）: ${e.message || e}`)
@@ -449,13 +591,13 @@ export const clearETLogs = async (fileName: string) => {
     const date = dayjs(new Date()).format('YYYY-MM-DD')
 
     let logsFile = await join('logs', fileName + '.' + date)
-    await writeFileContent(logsFile, '', { baseDir: BaseDirectory.Resource })
+    await writeFileContent(logsFile, '', { baseDir: getBaseDirectory() })
 
     logsFile = await join('logs', fileName + '.' + date + '.log')
-    await writeFileContent(logsFile, '', { baseDir: BaseDirectory.Resource })
+    await writeFileContent(logsFile, '', { baseDir: getBaseDirectory() })
 
     logsFile = await join('logs', 'easytier.log')
-    await writeFileContent(logsFile, '', { baseDir: BaseDirectory.Resource })
+    await writeFileContent(logsFile, '', { baseDir: getBaseDirectory() })
   } catch (e: any) {
     // 如果清理失败，只记录警告，不阻塞启动
     console.warn(`清理日志文件失败（不影响使用）: ${e.message || e}`)

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -90,13 +90,13 @@ export function getBaseDirectory(): BaseDirectory {
 
 /**
  * 一次性迁移：将 resourceDir 下的 config/、resource/、logs/ 复制到 appDataDir
- * 仅在 useAppData=true 时执行，使用 .migrated 标记避免重复
+ * 仅在 useAppData=true 时执行，使用 migrated-flag 标记避免重复
  */
 export async function migrateDataIfNeeded(): Promise<void> {
   if (!useAppData) return
 
   try {
-    const markerExists = await exists('.migrated', { baseDir: BaseDirectory.AppData })
+    const markerExists = await exists('migrated-flag', { baseDir: BaseDirectory.AppData })
     if (markerExists) return
 
     info('开始从 resourceDir 迁移数据到 appDataDir...')
@@ -157,7 +157,7 @@ export async function migrateDataIfNeeded(): Promise<void> {
     }
 
     // 写入迁移标记
-    await writeTextFile('.migrated', new Date().toISOString(), {
+    await writeTextFile('migrated-flag', new Date().toISOString(), {
       baseDir: BaseDirectory.AppData
     })
     info('数据迁移完成')

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -166,7 +166,11 @@ export async function readFileContent(
       return content
     }
   } catch (e: any) {
-    if (!JSON.stringify(e).includes('系统找不到指定的文件')) {
+    if (
+      !JSON.stringify(e).includes('系统找不到指定的文件') &&
+      !JSON.stringify(e).includes('No such file or directory') &&
+      !JSON.stringify(e).includes('not found')
+    ) {
       error(`Error reading file ${filePath}:${JSON.stringify(e)}`)
     }
     return ''

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -89,6 +89,24 @@ export function getBaseDirectory(): BaseDirectory {
 }
 
 /**
+ * 获取 easytier-cli 的 Tauri shell scope 名称（按优先级）
+ */
+export function getCliScopeNames(): string[] {
+  return useAppData
+    ? ['easytier-cli-appdata', 'easytier-cli-resource', 'easytier-cli']
+    : ['easytier-cli-resource', 'easytier-cli']
+}
+
+/**
+ * 获取 easytier-core 的 Tauri shell scope 名称（按优先级）
+ */
+export function getCoreScopeNames(): string[] {
+  return useAppData
+    ? ['easytier-core-appdata', 'easytier-core-resource', 'easytier-core']
+    : ['easytier-core-resource', 'easytier-core']
+}
+
+/**
  * 一次性迁移：将 resourceDir 下的 config/、resource/、logs/ 复制到 appDataDir
  * 仅在 useAppData=true 时执行，使用 migrated-flag 标记避免重复
  */

--- a/src/utils/fileUtil.ts
+++ b/src/utils/fileUtil.ts
@@ -107,6 +107,13 @@ export function getCoreScopeNames(): string[] {
 }
 
 /**
+ * 获取 nssm 的 Tauri shell scope 名称（按优先级）
+ */
+export function getNssmScopeNames(): string[] {
+  return useAppData ? ['nssm-appdata', 'nssm-resource', 'nssm'] : ['nssm-resource', 'nssm']
+}
+
+/**
  * 一次性迁移：将 resourceDir 下的 config/、resource/、logs/ 复制到 appDataDir
  * 仅在 useAppData=true 时执行，使用 migrated-flag 标记避免重复
  */

--- a/src/utils/serviceConfigUtil.ts
+++ b/src/utils/serviceConfigUtil.ts
@@ -16,7 +16,7 @@ export const getServiceInstallConfig = (configFileName: string): ServiceInstallC
   return {
     password: '',
     username: '',
-    installMethod: 'nssm', // 默认 NSSM 保证向后兼容
+    installMethod: 'native', // 默认原生方式: NSSM(Win)/systemd(Linux)/launchd(macOS)
     enableAutostart: true
   }
 }

--- a/src/utils/shellUtil.ts
+++ b/src/utils/shellUtil.ts
@@ -96,8 +96,8 @@ export async function executeCmd(
           msg: stderr.trim() || stdout.trim() || output
         }
       }
-      warn(`执行参数:${JSON.stringify(args)}`)
-      warn(`执行程序失败:${stdout || stderr || '未知错误'}`)
+      warn(`执行命令失败: ${program} ${args.join(' ')}`)
+      warn(`输出: ${stdout || stderr || '未知错误'}`)
       return {
         code: code || 403,
         msg: stderr.trim() || stdout.trim() || output
@@ -105,7 +105,7 @@ export async function executeCmd(
     }
     return stdout.trim() || output
   } catch (e: any) {
-    error(`执行程序失败:${JSON.stringify(e)}`)
+    error(`执行命令失败: ${program} ${args.join(' ')}: ${JSON.stringify(e)}`)
     throw e
   }
 }
@@ -259,7 +259,7 @@ export async function runEasyTierCli(args: string[]): Promise<any> {
     //   args
     // })
   } catch (e) {
-    error(`获取结果失败:${JSON.stringify(e)}`)
+    error(`执行 easytier-cli ${args.join(' ')} 失败: ${JSON.stringify(e)}`)
     return 403
   }
 }
@@ -272,7 +272,7 @@ export async function runCmd(args: string[]): Promise<any> {
       args
     })
   } catch (e) {
-    error(`获取结果失败:${JSON.stringify(e)}`)
+    error(`执行 run_cli [${args.join(' ')}] 失败: ${JSON.stringify(e)}`)
     return 403
   }
 }

--- a/src/utils/shellUtil.ts
+++ b/src/utils/shellUtil.ts
@@ -1,4 +1,4 @@
-import { CONFIG_PATH, NSSM_NAME } from '@/constants/easytier'
+import { CONFIG_PATH } from '@/constants/easytier'
 import { invoke } from '@tauri-apps/api/core'
 import { join } from '@tauri-apps/api/path'
 import { attachConsole, debug, error, info, warn } from '@tauri-apps/plugin-log'
@@ -8,6 +8,7 @@ import {
   getCliScopeNames,
   getCoreDir,
   getDataDir,
+  getNssmScopeNames,
   getResourceDir,
   readFileContent
 } from './fileUtil'
@@ -492,7 +493,7 @@ export const checkServiceOnWindows = (serviceName: string): Promise<any> => {
   return new Promise(async (resolve) => {
     try {
       const args = ['status', serviceName]
-      const res: any = await executeCmd(NSSM_NAME, args, { encoding: 'gbk' })
+      const res: any = await executeCmdWithFallback(getNssmScopeNames(), args, { encoding: 'gbk' })
       // debug('检测服务:' + JSON.stringify(res))
       // Can't open service!\r\r\nOpenService(): The specified service does not exist as an installed service.
       if (res && (res.code! === 3 || res.includes('does not exist'))) {
@@ -573,31 +574,33 @@ export const installServiceOnWindows = async (
       // const args10 = ['set', serviceName, 'AppStdout', `${logsPath}\\service.log`]
       // const args11 = ['set', serviceName, 'AppStderr', `${logsPath}\\service.log`]
       // const args12 = ['set', serviceName, 'AppTimestampLog', '1']
-      await executeCmd(NSSM_NAME, args1, { encoding: 'gbk' }).then(async (res) => {
-        info(`安装服务结果:${JSON.stringify(res)}`)
-        if (
-          res &&
-          (res.code! === 0 ||
-            res.code! === 1 ||
-            res.includes('success') ||
-            res.includes('installed'))
-        ) {
-          await executeCmd(NSSM_NAME, args2, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args3, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args4, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args5, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args6, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args7, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args8, { encoding: 'gbk' })
-          await executeCmd(NSSM_NAME, args9, { encoding: 'gbk' })
-          // await executeCmd(NSSM_NAME, args10, { encoding: 'gbk' })
-          // await executeCmd(NSSM_NAME, args11, { encoding: 'gbk' })
-          // await executeCmd(NSSM_NAME, args12, { encoding: 'gbk' })
-          resolve(true)
-          return
+      await executeCmdWithFallback(getNssmScopeNames(), args1, { encoding: 'gbk' }).then(
+        async (res) => {
+          info(`安装服务结果:${JSON.stringify(res)}`)
+          if (
+            res &&
+            (res.code! === 0 ||
+              res.code! === 1 ||
+              res.includes('success') ||
+              res.includes('installed'))
+          ) {
+            await executeCmdWithFallback(getNssmScopeNames(), args2, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args3, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args4, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args5, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args6, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args7, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args8, { encoding: 'gbk' })
+            await executeCmdWithFallback(getNssmScopeNames(), args9, { encoding: 'gbk' })
+            // await executeCmdWithFallback(getNssmScopeNames(), args10, { encoding: 'gbk' })
+            // await executeCmdWithFallback(getNssmScopeNames(), args11, { encoding: 'gbk' })
+            // await executeCmdWithFallback(getNssmScopeNames(), args12, { encoding: 'gbk' })
+            resolve(true)
+            return
+          }
+          resolve(false)
         }
-        resolve(false)
-      })
+      )
     } catch (e: any) {
       error(`安装服务失败:${e}`)
       resolve(false)
@@ -613,7 +616,7 @@ export const uninstallServiceOnWindows = (serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
       const args = ['remove', serviceName, 'confirm']
-      const res: any = await executeCmd(NSSM_NAME, args, { encoding: 'gbk' })
+      const res: any = await executeCmdWithFallback(getNssmScopeNames(), args, { encoding: 'gbk' })
       info(`删除服务:${JSON.stringify(res)}`)
       if (res && (res.code! === 0 || res.includes('success'))) {
         resolve(true)
@@ -635,7 +638,7 @@ export const startServiceOnWindows = (serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
       const args = ['start', serviceName]
-      await executeCmd(NSSM_NAME, args, { encoding: 'gbk' })
+      await executeCmdWithFallback(getNssmScopeNames(), args, { encoding: 'gbk' })
       await sleep(2000)
       const res = await checkServiceOnWindows(serviceName)
       info('启动服务:' + JSON.stringify(res))
@@ -660,7 +663,7 @@ export const stopServiceOnWindows = (serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
       const args = ['stop', serviceName]
-      await executeCmd(NSSM_NAME, args, { encoding: 'gbk' })
+      await executeCmdWithFallback(getNssmScopeNames(), args, { encoding: 'gbk' })
       await sleep(2000)
       const res = await checkServiceOnWindows(serviceName)
       info('停止服务:' + JSON.stringify(res))

--- a/src/utils/shellUtil.ts
+++ b/src/utils/shellUtil.ts
@@ -3,7 +3,14 @@ import { invoke } from '@tauri-apps/api/core'
 import { join } from '@tauri-apps/api/path'
 import { attachConsole, debug, error, info, warn } from '@tauri-apps/plugin-log'
 import { Command, type SpawnOptions } from '@tauri-apps/plugin-shell'
-import { getCliDir, getCoreDir, getDataDir, getResourceDir, readFileContent } from './fileUtil'
+import {
+  getCliDir,
+  getCliScopeNames,
+  getCoreDir,
+  getDataDir,
+  getResourceDir,
+  readFileContent
+} from './fileUtil'
 import { getPlatform, sleep } from './sysUtil'
 import * as toml from 'smol-toml'
 
@@ -107,6 +114,24 @@ export async function executeCmd(
   } catch (e: any) {
     error(`执行命令失败: ${program} ${args.join(' ')}: ${JSON.stringify(e)}`)
     throw e
+  }
+}
+
+/**
+ * 依次尝试多个 scope 名称执行命令，第一个成功的返回结果
+ */
+async function executeCmdWithFallback(
+  scopeNames: string[],
+  args: string[] = [],
+  options: SpawnOptions = {}
+): Promise<any> {
+  for (let i = 0; i < scopeNames.length; i++) {
+    try {
+      return await executeCmd(scopeNames[i], args, options)
+    } catch (e) {
+      if (i === scopeNames.length - 1) throw e
+      warn(`${scopeNames[i]} 不可用，尝试下一个: ${scopeNames[i + 1]}`)
+    }
   }
 }
 
@@ -251,7 +276,7 @@ export async function runEasyTierCoreWeb(url: string): Promise<any> {
 // 运行 easytier-cli 配置
 export async function runEasyTierCli(args: string[]): Promise<any> {
   try {
-    return await executeCmd('easytier-cli', args)
+    return await executeCmdWithFallback(getCliScopeNames(), args)
     // 使用rust api 会出现卡顿
     // const program = await getCliDir()
     // return await invoke('run_cli', {
@@ -708,7 +733,7 @@ export const installServiceWithOfficialCli = async (
       )
 
       // 执行安装
-      const res: any = await executeCmd('easytier-cli', args, { encoding: 'gbk' })
+      const res: any = await executeCmdWithFallback(getCliScopeNames(), args, { encoding: 'gbk' })
 
       info(`官方CLI安装服务结果: ${JSON.stringify(res)}`)
 
@@ -736,7 +761,7 @@ export const installServiceWithOfficialCli = async (
 export const uninstallServiceWithOfficialCli = async (_serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
-      const res: any = await executeCmd('easytier-cli', ['service', 'uninstall'], {
+      const res: any = await executeCmdWithFallback(getCliScopeNames(), ['service', 'uninstall'], {
         encoding: 'gbk'
       })
       info(`官方CLI卸载服务结果: ${JSON.stringify(res)}`)
@@ -765,7 +790,9 @@ export const uninstallServiceWithOfficialCli = async (_serviceName: string) => {
 export const checkServiceWithOfficialCli = async (_serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
-      const res: any = await executeCmd('easytier-cli', ['service', 'status'], { encoding: 'gbk' })
+      const res: any = await executeCmdWithFallback(getCliScopeNames(), ['service', 'status'], {
+        encoding: 'gbk'
+      })
 
       // info(`官方CLI检查服务状态: ${JSON.stringify(res)}`)
 
@@ -834,7 +861,7 @@ export const checkServiceWithOfficialCli = async (_serviceName: string) => {
 export const startServiceWithOfficialCli = async (serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
-      await executeCmd('easytier-cli', ['service', 'start'], { encoding: 'gbk' })
+      await executeCmdWithFallback(getCliScopeNames(), ['service', 'start'], { encoding: 'gbk' })
       await sleep(2000)
 
       const status = await checkServiceWithOfficialCli(serviceName)
@@ -852,7 +879,7 @@ export const startServiceWithOfficialCli = async (serviceName: string) => {
 export const stopServiceWithOfficialCli = async (serviceName: string) => {
   return new Promise(async (resolve) => {
     try {
-      await executeCmd('easytier-cli', ['service', 'stop'], { encoding: 'gbk' })
+      await executeCmdWithFallback(getCliScopeNames(), ['service', 'stop'], { encoding: 'gbk' })
       await sleep(2000)
 
       const status = await checkServiceWithOfficialCli(serviceName)

--- a/src/utils/shellUtil.ts
+++ b/src/utils/shellUtil.ts
@@ -1,9 +1,9 @@
 import { CONFIG_PATH, NSSM_NAME } from '@/constants/easytier'
 import { invoke } from '@tauri-apps/api/core'
-import { join, resourceDir } from '@tauri-apps/api/path'
+import { join } from '@tauri-apps/api/path'
 import { attachConsole, debug, error, info, warn } from '@tauri-apps/plugin-log'
 import { Command, type SpawnOptions } from '@tauri-apps/plugin-shell'
-import { getCliDir, getCoreDir, getResourceDir, readFileContent } from './fileUtil'
+import { getCliDir, getCoreDir, getDataDir, getResourceDir, readFileContent } from './fileUtil'
 import { getPlatform, sleep } from './sysUtil'
 import * as toml from 'smol-toml'
 
@@ -203,7 +203,7 @@ export async function executeBack(
 // 运行 easytier-core 配置
 export async function runEasyTierCore(configFileName: string): Promise<any> {
   try {
-    const configPath = await join(await resourceDir(), CONFIG_PATH, configFileName)
+    const configPath = await join(getDataDir(), CONFIG_PATH, configFileName)
     const program = await getCoreDir()
 
     // 读取配置文件获取日志配置

--- a/src/utils/shellUtil.ts
+++ b/src/utils/shellUtil.ts
@@ -10,6 +10,9 @@ import * as toml from 'smol-toml'
 // 启用 TargetKind::Webview 后，这个函数将把日志打印到浏览器控制台
 attachConsole()
 
+/** 根据平台返回合适的编码 */
+const platformEncoding = async () => ((await getPlatform()) === 'windows' ? 'gbk' : 'utf-8')
+
 /**
  * 从配置文件中读取日志配置
  * @param configFileName 配置文件名
@@ -336,13 +339,12 @@ export async function killProcessWithSudo(pid: number, force: boolean = false): 
   }
 }
 
-// Windows 结束所有 easytier-core 进程
-export async function killAllEasyTierCoreProcessWin() {
-  return await executeCmd('taskkill', ['/IM', 'easytier-core.exe', '/F'])
-}
-
-// Linux/macOS 结束所有 easytier-core 进程
-export async function killAllEasyTierCoreProcessUnix() {
+// 跨平台结束所有 easytier-core 进程
+export async function killAllEasyTierCoreProcess() {
+  const platform = await getPlatform()
+  if (platform === 'windows') {
+    return await executeCmd('taskkill', ['/IM', 'easytier-core.exe', '/F'], { encoding: 'gbk' })
+  }
   return await executeCmd('killall', ['easytier-core'])
 }
 
@@ -399,75 +401,51 @@ export const getRunningProcesses = async (
     }
     executeCmd(program, args, { encoding })
       .then((res) => {
-        res = JSON.parse(res || '[]')
-        res = Array.isArray(res) ? res : []
-        const result = res.filter((r) => !r.name.includes('powershell.exe'))
-        if (result.length === 0) {
-          resolve(processInfo)
-          return
-        }
         if (platform === 'windows') {
-          // 解析JSON 输出
-          result.forEach((p) => {
+          // Windows: 解析 PowerShell JSON 输出
+          let parsed = JSON.parse(res || '[]')
+          parsed = Array.isArray(parsed) ? parsed : [parsed]
+          const result = parsed.filter((r: any) => !r.name?.includes('powershell.exe'))
+          result.forEach((p: any) => {
             if (p.commandLine && p.commandLine.includes(programName)) {
-              const process = {
+              processInfo.push({
                 name: p.name,
                 commandLine: p.commandLine,
                 path: p.path,
                 pid: parseInt(p.pid, 10) || 0,
                 memory: parseInt(p.memory, 10) || 0,
                 fileName: programName
-              }
-              processInfo.push(process)
+              })
             }
           })
-          // 解析 PowerShell 的 CSV 输出
-          // const lines = result.trim().split('\n').slice(1) // 去掉标题行
-          // lines.forEach((line: string) => {
-          //   // "Caption","CommandLine","ExecutablePath","ProcessId","WorkingSetSize"
-          //   const values = line
-          //     .slice(1, -1)
-          //     .split('","')
-          //     .map((v) => v.trim())
-          //
-          //   if (values.length >= 5) {
-          //     const [caption, commandLine, executablePath, processId, workingSetSize] = values
-          //     if (commandLine && commandLine.includes(programName)) {
-          //       const process = {
-          //         name: caption,
-          //         commandLine: commandLine,
-          //         path: executablePath,
-          //         pid: parseInt(processId, 10),
-          //         memory: parseInt(workingSetSize, 10),
-          //         fileName: programName
-          //       }
-          //       processInfo.push(process)
-          //     }
-          //   }
-          // })
         } else if (platform === 'macos' || platform === 'linux') {
-          // 解析 macOS 和 Linux 的 ps 输出
-          const lines = result.trim().split('\n')
+          // Unix: 解析 ps 文本输出
+          const output = typeof res === 'string' ? res : res?.msg || ''
+          if (!output.trim()) {
+            resolve(processInfo)
+            return
+          }
+          const lines = output.trim().split('\n')
           lines.forEach((line: string) => {
+            // 跳过 grep 自身的进程
+            if (line.includes('grep')) return
             const parts = line.trim().split(/\s+/)
             if (parts.length >= 4) {
               const [comm, ...argsParts] = parts
-              const pidIndex = argsParts.findIndex((p) => !isNaN(parseInt(p, 10)))
+              const pidIndex = argsParts.findIndex((p: string) => !isNaN(parseInt(p, 10)))
               if (pidIndex > -1) {
                 const commandLine = argsParts.slice(0, pidIndex).join(' ')
                 const pid = argsParts[pidIndex]
                 const rss = argsParts[pidIndex + 1]
-
                 if (commandLine.includes(programName)) {
-                  const process = {
+                  processInfo.push({
                     name: comm,
                     commandLine: commandLine,
-                    path: comm, // ps 命令不直接提供可执行文件路径
+                    path: comm,
                     pid: parseInt(pid, 10),
-                    memory: parseInt(rss, 10) * 1024, // rss 单位是 KB
+                    memory: parseInt(rss, 10) * 1024,
                     fileName: programName
-                  }
-                  processInfo.push(process)
+                  })
                 }
               }
             }
@@ -887,56 +865,46 @@ export const stopServiceWithOfficialCli = async (serviceName: string) => {
 }
 
 /**
- * 自动检测服务安装方式
+ * 自动检测服务安装方式（跨平台）
  */
 export const detectServiceInstallMethod = async (
   serviceName: string
-): Promise<'nssm' | 'official' | 'none'> => {
-  // 从 serviceName 中提取 configFileName (移除 'easytier-' 前缀)
+): Promise<'native' | 'official' | 'none'> => {
   const configFileName = serviceName.replace(/^easytier-/, '')
-
-  // 优先从 localStorage 读取保存的安装方式
   const SERVICE_CONFIG_PREFIX = 'service-config:'
   const savedConfigStr = localStorage.getItem(SERVICE_CONFIG_PREFIX + configFileName)
+  const platform = await getPlatform()
 
   if (savedConfigStr) {
     try {
       const savedConfig = JSON.parse(savedConfigStr)
       const savedMethod = savedConfig.installMethod
 
-      // 如果有保存的安装方式，直接检查该方式的状态
-      if (savedMethod === 'nssm') {
-        const status = await checkServiceOnWindows(serviceName)
-        if (status && status !== false) {
-          return 'nssm'
-        }
-        // 如果服务已卸载，返回 none
-        return 'none'
+      if (savedMethod === 'native' || savedMethod === 'nssm') {
+        const status = await checkServiceNative(serviceName)
+        return status && status !== false ? 'native' : 'none'
       } else if (savedMethod === 'official') {
         const status = await checkServiceWithOfficialCli(serviceName)
-        if (status && status !== false) {
-          return 'official'
-        }
-        // 如果服务已卸载，返回 none
-        return 'none'
+        return status && status !== false ? 'official' : 'none'
       }
     } catch (e) {
-      // 解析失败，继续使用自动检测
       error(`解析服务配置失败: ${e}`)
     }
   }
 
-  // 没有保存的配置，使用自动检测（向后兼容旧版本安装的服务）
-  // 先检查 NSSM
-  const nssmStatus = await checkServiceOnWindows(serviceName)
-  if (nssmStatus && nssmStatus !== false) {
-    return 'nssm'
+  // 没有保存的配置，使用自动检测
+  // 先检查原生方式 (NSSM/systemd/launchd)
+  const nativeStatus = await checkServiceNative(serviceName)
+  if (nativeStatus && nativeStatus !== false) {
+    return 'native'
   }
 
-  // 再检查官方 CLI
-  const officialStatus = await checkServiceWithOfficialCli(serviceName)
-  if (officialStatus && officialStatus !== false) {
-    return 'official'
+  // 再检查官方 CLI（仅 Windows 和 Linux 有意义）
+  if (platform === 'windows' || platform === 'linux') {
+    const officialStatus = await checkServiceWithOfficialCli(serviceName)
+    if (officialStatus && officialStatus !== false) {
+      return 'official'
+    }
   }
 
   return 'none'
@@ -1005,6 +973,352 @@ export const delRouteOnWindows = async (ip: string) => {
       resolve(false)
     }
   })
+}
+
+// ==================== systemd 服务管理 (Linux) ====================
+
+/** 获取 systemd 服务单元名 */
+const systemdUnitName = (serviceName: string) => `${serviceName}.service`
+
+/** Linux: 检测 systemd 服务状态 */
+export const checkServiceSystemd = async (serviceName: string): Promise<any> => {
+  try {
+    const res = await executeCmd('systemctl', ['is-active', systemdUnitName(serviceName)])
+    const output = typeof res === 'string' ? res.trim() : res?.msg?.trim() || ''
+    if (output === 'active') return 'SERVICE_RUNNING'
+    if (output === 'inactive' || output === 'failed') return 'SERVICE_STOPPED'
+    return false
+  } catch {
+    return false
+  }
+}
+
+/** Linux: 安装 systemd 服务 */
+export const installServiceSystemd = async (
+  serviceName: string,
+  configPath: string,
+  configFileName: string,
+  options: { description?: string; disableAutostart?: boolean } = {}
+): Promise<boolean> => {
+  try {
+    const appDirectory = await getResourceDir()
+    const corePath = await join(appDirectory, 'easytier-core')
+    const { logDir, logLevel } = await getLogConfigFromFile(configFileName)
+    const desc = options.description || `EasyTier P2P Network - ${serviceName}`
+
+    const unitContent = [
+      '[Unit]',
+      `Description=${desc}`,
+      'After=network.target',
+      '',
+      '[Service]',
+      'Type=simple',
+      `WorkingDirectory=${appDirectory}`,
+      `ExecStart=${corePath} --file-log-dir "${logDir}" --file-log-level ${logLevel} --config-file "${configPath}"`,
+      'Restart=on-failure',
+      'RestartSec=5',
+      '',
+      '[Install]',
+      'WantedBy=multi-user.target'
+    ].join('\n')
+
+    // 写入 unit 文件（需要 sudo）
+    const unitPath = `/etc/systemd/system/${systemdUnitName(serviceName)}`
+    await executeCmd('sudo', [
+      'sh',
+      '-c',
+      `cat > ${unitPath} << 'EOFUNIT'\n${unitContent}\nEOFUNIT`
+    ])
+    await executeCmd('sudo', ['systemctl', 'daemon-reload'])
+
+    if (!options.disableAutostart) {
+      await executeCmd('sudo', ['systemctl', 'enable', systemdUnitName(serviceName)])
+    }
+    return true
+  } catch (e: any) {
+    error(`安装 systemd 服务失败: ${e}`)
+    return false
+  }
+}
+
+/** Linux: 卸载 systemd 服务 */
+export const uninstallServiceSystemd = async (serviceName: string): Promise<boolean> => {
+  try {
+    await executeCmd('sudo', ['systemctl', 'stop', systemdUnitName(serviceName)])
+    await executeCmd('sudo', ['systemctl', 'disable', systemdUnitName(serviceName)])
+    await executeCmd('sudo', ['rm', '-f', `/etc/systemd/system/${systemdUnitName(serviceName)}`])
+    await executeCmd('sudo', ['systemctl', 'daemon-reload'])
+    return true
+  } catch (e: any) {
+    error(`卸载 systemd 服务失败: ${e}`)
+    return false
+  }
+}
+
+/** Linux: 启动 systemd 服务 */
+export const startServiceSystemd = async (serviceName: string): Promise<boolean> => {
+  try {
+    await executeCmd('sudo', ['systemctl', 'start', systemdUnitName(serviceName)])
+    await sleep(2000)
+    const status = await checkServiceSystemd(serviceName)
+    return status === 'SERVICE_RUNNING'
+  } catch (e: any) {
+    error(`启动 systemd 服务失败: ${e}`)
+    return false
+  }
+}
+
+/** Linux: 停止 systemd 服务 */
+export const stopServiceSystemd = async (serviceName: string): Promise<boolean> => {
+  try {
+    await executeCmd('sudo', ['systemctl', 'stop', systemdUnitName(serviceName)])
+    await sleep(2000)
+    const status = await checkServiceSystemd(serviceName)
+    return status === 'SERVICE_STOPPED' || status === false
+  } catch (e: any) {
+    error(`停止 systemd 服务失败: ${e}`)
+    return false
+  }
+}
+
+// ==================== launchd 服务管理 (macOS) ====================
+
+/** 获取 launchd plist 标签 */
+const launchdLabel = (serviceName: string) => `com.easytier.${serviceName}`
+/** 获取 launchd plist 路径 */
+const launchdPlistPath = (serviceName: string) =>
+  `$HOME/Library/LaunchAgents/${launchdLabel(serviceName)}.plist`
+
+/** macOS: 检测 launchd 服务状态 */
+export const checkServiceLaunchd = async (serviceName: string): Promise<any> => {
+  try {
+    const res = await executeCmd('launchctl', ['list', launchdLabel(serviceName)])
+    const output = typeof res === 'string' ? res : ''
+    if (output.includes(launchdLabel(serviceName))) return 'SERVICE_RUNNING'
+    return false
+  } catch {
+    // launchctl list 对不存在的服务会报错
+    return false
+  }
+}
+
+/** macOS: 安装 launchd 服务 */
+export const installServiceLaunchd = async (
+  serviceName: string,
+  configPath: string,
+  configFileName: string,
+  options: { description?: string; disableAutostart?: boolean } = {}
+): Promise<boolean> => {
+  try {
+    const appDirectory = await getResourceDir()
+    const corePath = await join(appDirectory, 'easytier-core')
+    const { logDir, logLevel } = await getLogConfigFromFile(configFileName)
+    const label = launchdLabel(serviceName)
+
+    const plistContent = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+      '<plist version="1.0">',
+      '<dict>',
+      `  <key>Label</key><string>${label}</string>`,
+      '  <key>ProgramArguments</key>',
+      '  <array>',
+      `    <string>${corePath}</string>`,
+      `    <string>--file-log-dir</string><string>${logDir}</string>`,
+      `    <string>--file-log-level</string><string>${logLevel}</string>`,
+      `    <string>--config-file</string><string>${configPath}</string>`,
+      '  </array>',
+      `  <key>WorkingDirectory</key><string>${appDirectory}</string>`,
+      `  <key>RunAtLoad</key><${!options.disableAutostart}/>`,
+      '  <key>KeepAlive</key><true/>',
+      '</dict>',
+      '</plist>'
+    ].join('\n')
+
+    const plistPath = launchdPlistPath(serviceName)
+    // 展开 $HOME 并写入 plist
+    await executeCmd('sh', ['-c', `cat > ${plistPath} << 'EOFPLIST'\n${plistContent}\nEOFPLIST`])
+    await executeCmd('sh', ['-c', `launchctl load ${plistPath}`])
+    return true
+  } catch (e: any) {
+    error(`安装 launchd 服务失败: ${e}`)
+    return false
+  }
+}
+
+/** macOS: 卸载 launchd 服务 */
+export const uninstallServiceLaunchd = async (serviceName: string): Promise<boolean> => {
+  try {
+    const plistPath = launchdPlistPath(serviceName)
+    await executeCmd('sh', ['-c', `launchctl unload ${plistPath}`])
+    await executeCmd('sh', ['-c', `rm -f ${plistPath}`])
+    return true
+  } catch (e: any) {
+    error(`卸载 launchd 服务失败: ${e}`)
+    return false
+  }
+}
+
+/** macOS: 启动 launchd 服务 */
+export const startServiceLaunchd = async (serviceName: string): Promise<boolean> => {
+  try {
+    await executeCmd('launchctl', ['start', launchdLabel(serviceName)])
+    await sleep(2000)
+    const status = await checkServiceLaunchd(serviceName)
+    return status === 'SERVICE_RUNNING'
+  } catch (e: any) {
+    error(`启动 launchd 服务失败: ${e}`)
+    return false
+  }
+}
+
+/** macOS: 停止 launchd 服务 */
+export const stopServiceLaunchd = async (serviceName: string): Promise<boolean> => {
+  try {
+    await executeCmd('launchctl', ['stop', launchdLabel(serviceName)])
+    await sleep(2000)
+    const status = await checkServiceLaunchd(serviceName)
+    return status === 'SERVICE_STOPPED' || status === false
+  } catch (e: any) {
+    error(`停止 launchd 服务失败: ${e}`)
+    return false
+  }
+}
+
+// ==================== 跨平台原生服务统一接口 ====================
+
+/** 跨平台: 检测原生服务状态 (NSSM/systemd/launchd) */
+export const checkServiceNative = async (serviceName: string): Promise<any> => {
+  const platform = await getPlatform()
+  if (platform === 'windows') return checkServiceOnWindows(serviceName)
+  if (platform === 'linux') return checkServiceSystemd(serviceName)
+  if (platform === 'macos') return checkServiceLaunchd(serviceName)
+  return false
+}
+
+/** 跨平台: 安装原生服务 */
+export const installServiceNative = async (
+  serviceName: string,
+  configPath: string,
+  configFileName: string,
+  options: {
+    description?: string
+    displayName?: string
+    disableAutostart?: boolean
+    username?: string
+    password?: string
+  } = {}
+): Promise<boolean> => {
+  const platform = await getPlatform()
+  if (platform === 'windows') {
+    const args = await buildCoreArgsWithLogConfig(configFileName, configPath)
+    const installOptions =
+      options.username && options.password
+        ? { username: options.username, password: options.password }
+        : undefined
+    return (await installServiceOnWindows(serviceName, args, installOptions)) as boolean
+  }
+  if (platform === 'linux') {
+    return installServiceSystemd(serviceName, configPath, configFileName, options)
+  }
+  if (platform === 'macos') {
+    return installServiceLaunchd(serviceName, configPath, configFileName, options)
+  }
+  return false
+}
+
+/** 跨平台: 卸载原生服务 */
+export const uninstallServiceNative = async (serviceName: string): Promise<boolean> => {
+  const platform = await getPlatform()
+  if (platform === 'windows') return (await uninstallServiceOnWindows(serviceName)) as boolean
+  if (platform === 'linux') return uninstallServiceSystemd(serviceName)
+  if (platform === 'macos') return uninstallServiceLaunchd(serviceName)
+  return false
+}
+
+/** 跨平台: 启动原生服务 */
+export const startServiceNative = async (serviceName: string): Promise<boolean> => {
+  const platform = await getPlatform()
+  if (platform === 'windows') return (await startServiceOnWindows(serviceName)) as boolean
+  if (platform === 'linux') return startServiceSystemd(serviceName)
+  if (platform === 'macos') return startServiceLaunchd(serviceName)
+  return false
+}
+
+/** 跨平台: 停止原生服务 */
+export const stopServiceNative = async (serviceName: string): Promise<boolean> => {
+  const platform = await getPlatform()
+  if (platform === 'windows') return (await stopServiceOnWindows(serviceName)) as boolean
+  if (platform === 'linux') return stopServiceSystemd(serviceName)
+  if (platform === 'macos') return stopServiceLaunchd(serviceName)
+  return false
+}
+
+// ==================== 跨平台路由管理 ====================
+
+/** 跨平台: 检测路由是否存在 */
+export const checkRoute = async (ip: string): Promise<boolean> => {
+  try {
+    const platform = await getPlatform()
+    const enc = await platformEncoding()
+    if (platform === 'windows') {
+      const res = await executeCmd('route', ['print', '-4', ip], { encoding: enc })
+      return typeof res === 'string' && res.includes(ip)
+    } else if (platform === 'linux') {
+      const res = await executeCmd('ip', ['route', 'show', ip])
+      return typeof res === 'string' && res.includes(ip)
+    } else {
+      // macOS
+      const res = await executeCmd('sh', ['-c', `netstat -rn | grep ${ip}`])
+      return typeof res === 'string' && res.includes(ip)
+    }
+  } catch {
+    return false
+  }
+}
+
+/** 跨平台: 添加路由 */
+export const addRoute = async (ip: string): Promise<boolean> => {
+  try {
+    const platform = await getPlatform()
+    const enc = await platformEncoding()
+    if (platform === 'windows') {
+      const res = await executeCmd('route', ['add', ip, 'mask', '255.255.255.255', '0.0.0.0'], {
+        encoding: enc
+      })
+      return typeof res === 'string' && res.includes('OK!')
+    } else if (platform === 'linux') {
+      await executeCmd('sudo', ['ip', 'route', 'add', `${ip}/32`, 'dev', 'lo'])
+      return true
+    } else {
+      await executeCmd('sudo', ['route', 'add', '-host', ip, '127.0.0.1'])
+      return true
+    }
+  } catch (e: any) {
+    error(`添加路由失败: ${e}`)
+    return false
+  }
+}
+
+/** 跨平台: 删除路由 */
+export const delRoute = async (ip: string): Promise<boolean> => {
+  try {
+    const platform = await getPlatform()
+    const enc = await platformEncoding()
+    if (platform === 'windows') {
+      const res = await executeCmd('route', ['delete', ip], { encoding: enc })
+      return typeof res === 'string' && res.includes('OK!')
+    } else if (platform === 'linux') {
+      await executeCmd('sudo', ['ip', 'route', 'del', `${ip}/32`])
+      return true
+    } else {
+      await executeCmd('sudo', ['route', 'delete', '-host', ip])
+      return true
+    }
+  } catch (e: any) {
+    error(`删除路由失败: ${e}`)
+    return false
+  }
 }
 
 export const safeJsonParse = (str: string, fallback: any = {}) => {

--- a/src/views/config/index.vue
+++ b/src/views/config/index.vue
@@ -15,18 +15,17 @@ import {
   writeFileContent
 } from '@/utils/fileUtil'
 import {
-  buildCoreArgsWithLogConfig,
-  checkServiceOnWindows,
+  checkServiceNative,
   checkServiceWithOfficialCli,
   detectServiceInstallMethod,
-  installServiceOnWindows,
+  installServiceNative,
   installServiceWithOfficialCli,
   runEasyTierCli,
-  startServiceOnWindows,
+  startServiceNative,
   startServiceWithOfficialCli,
-  stopServiceOnWindows,
+  stopServiceNative,
   stopServiceWithOfficialCli,
-  uninstallServiceOnWindows,
+  uninstallServiceNative,
   uninstallServiceWithOfficialCli
 } from '@/utils/shellUtil'
 import {
@@ -65,7 +64,7 @@ const logsDir = ref('')
 const installServiceDialogVisible = ref(false)
 const currentInstallRow = ref<any>(null)
 const serviceInstallForm = ref({
-  installMethod: 'nssm' as 'nssm' | 'official',
+  installMethod: 'native' as 'native' | 'official',
   description: '',
   displayName: '',
   enableAutostart: true,
@@ -81,10 +80,10 @@ const checkServiceStatus = async () => {
     // 检测安装方式
     const installMethod = await detectServiceInstallMethod(serviceName)
 
-    if (installMethod === 'nssm') {
-      const status = await checkServiceOnWindows(serviceName)
+    if (installMethod === 'native') {
+      const status = await checkServiceNative(serviceName)
       item.serviceStatus = serviceStatusDict(status as string | boolean)
-      item.installMethod = 'nssm'
+      item.installMethod = 'native'
     } else if (installMethod === 'official') {
       const status = await checkServiceWithOfficialCli(serviceName)
       item.serviceStatus = serviceStatusDict(status as string | boolean)
@@ -341,7 +340,7 @@ const saveConfigAction = async () => {
         // formData.value.file_logger.dir = formData.value.file_logger.dir
         //   ? formData.value.file_logger.dir
         //   : logsDir.value
-        formData.value.file_logger.dir = resourceDirPath + '\\' + LOG_PATH
+        formData.value.file_logger.dir = await join(resourceDirPath, LOG_PATH)
         formData.value.file_logger.file = configFileName.value
         if (
           !formData.value.proxy_network ||
@@ -433,7 +432,7 @@ const saveConfigAction = async () => {
         ...parseValue,
         file_logger: {
           level: parseValue.file_logger?.level ? parseValue.file_logger?.level : 'error',
-          dir: resourceDirPath + '\\' + LOG_PATH, // parseValue.file_logger?.dir ? parseValue.file_logger?.dir : logsDir.value,
+          dir: await join(resourceDirPath, LOG_PATH),
           file: configFileName.value
         }
       }
@@ -468,9 +467,9 @@ const delConfig = async (row?: any) => {
     type: 'warning'
   })
     .then(async () => {
-      const serviceStatus = await checkServiceOnWindows(PREFIX_SVC + row?.configFileName)
+      const serviceStatus = await checkServiceNative(PREFIX_SVC + row?.configFileName)
       if (serviceStatus) {
-        await uninstallServiceOnWindows(PREFIX_SVC + row?.configFileName)
+        await uninstallServiceNative(PREFIX_SVC + row?.configFileName)
       }
       await deleteFileOrDir(CONFIG_PATH + '/' + row?.fileName)
       ElNotification({
@@ -546,7 +545,7 @@ const confirmInstallService = async () => {
     const supported = await checkOfficialCliSupport()
     if (!supported) {
       ElMessageBox.confirm(
-        '当前版本不支持官方服务管理功能，是否使用 NSSM 方式安装？',
+        '当前版本不支持官方服务管理功能，是否使用原生方式安装？',
         t('common.reminder'),
         {
           confirmButtonText: t('common.ok'),
@@ -554,16 +553,11 @@ const confirmInstallService = async () => {
           type: 'warning'
         }
       ).then(async () => {
-        serviceInstallForm.value.installMethod = 'nssm'
-        const args = await buildCoreArgsWithLogConfig(row.fileName, configPath)
-        const installOptions =
-          serviceInstallForm.value.username && serviceInstallForm.value.password
-            ? {
-                username: serviceInstallForm.value.username,
-                password: serviceInstallForm.value.password
-              }
-            : undefined
-        result = (await installServiceOnWindows(serviceName, args, installOptions)) as boolean
+        serviceInstallForm.value.installMethod = 'native'
+        result = await installServiceNative(serviceName, configPath, row.fileName, {
+          username: serviceInstallForm.value.username,
+          password: serviceInstallForm.value.password
+        })
         handleInstallResult(result)
       })
       return
@@ -575,15 +569,13 @@ const confirmInstallService = async () => {
       disableAutostart: !serviceInstallForm.value.enableAutostart
     })) as boolean
   } else {
-    const args = await buildCoreArgsWithLogConfig(row.fileName, configPath)
-    const installOptions =
-      serviceInstallForm.value.username && serviceInstallForm.value.password
-        ? {
-            username: serviceInstallForm.value.username,
-            password: serviceInstallForm.value.password
-          }
-        : undefined
-    result = (await installServiceOnWindows(serviceName, args, installOptions)) as boolean
+    result = await installServiceNative(serviceName, configPath, row.fileName, {
+      description: serviceInstallForm.value.description,
+      displayName: serviceInstallForm.value.displayName,
+      disableAutostart: !serviceInstallForm.value.enableAutostart,
+      username: serviceInstallForm.value.username,
+      password: serviceInstallForm.value.password
+    })
   }
 
   handleInstallResult(result)
@@ -621,7 +613,7 @@ const uninstallServiceHandle = async (row: any) => {
     if (installMethod === 'official') {
       res = (await uninstallServiceWithOfficialCli(serviceName)) as boolean
     } else {
-      res = (await uninstallServiceOnWindows(serviceName)) as boolean
+      res = (await uninstallServiceNative(serviceName)) as boolean
     }
 
     info(`卸载服务:${JSON.stringify(res)}`)
@@ -644,7 +636,7 @@ const startServiceHandle = async (row: any) => {
   if (installMethod === 'official') {
     res = (await startServiceWithOfficialCli(serviceName)) as boolean
   } else {
-    res = (await startServiceOnWindows(serviceName)) as boolean
+    res = (await startServiceNative(serviceName)) as boolean
   }
 
   info(`启动服务:${JSON.stringify(res)}`)
@@ -673,7 +665,7 @@ const stopServiceHandle = async (row: any) => {
   if (installMethod === 'official') {
     res = (await stopServiceWithOfficialCli(serviceName)) as boolean
   } else {
-    res = (await stopServiceOnWindows(serviceName)) as boolean
+    res = (await stopServiceNative(serviceName)) as boolean
   }
 
   info(`停止服务:${JSON.stringify(res)}`)
@@ -751,7 +743,7 @@ onMounted(async () => {
       </div>
 
       <div>
-        <el-text v-if="easyTierStore.os === 'windows'" type="info" effect="dark"
+        <el-text type="info" effect="dark"
           >安装服务前检查程序尽量不要放在含有空格、中文路径的目录下；如果组网是由服务启动的，则只能使用启动服务和停止服务，无法使用首页的启动和停止
         </el-text>
       </div>
@@ -791,7 +783,6 @@ onMounted(async () => {
           header-align="center"
           align="center"
           width="120"
-          v-if="easyTierStore.os === 'windows'"
         >
           <template #default="{ row }">
             <el-tag
@@ -835,13 +826,7 @@ onMounted(async () => {
             </div>
           </template>
         </el-table-column>
-        <el-table-column
-          label="服务操作"
-          width="150"
-          header-align="center"
-          align="center"
-          v-if="easyTierStore.os === 'windows'"
-        >
+        <el-table-column label="服务操作" width="150" header-align="center" align="center">
           <template #default="{ row }">
             <div class="flex flex-col gap-5px">
               <div class="flex justify-center gap-5px">
@@ -984,13 +969,13 @@ onMounted(async () => {
       <ElForm :model="serviceInstallForm" label-width="120px">
         <ElFormItem :label="t('easytier.serviceInstallMethod')">
           <ElRadioGroup v-model="serviceInstallForm.installMethod">
-            <ElRadio label="nssm">{{ t('easytier.installMethodNssm') }}</ElRadio>
+            <ElRadio label="native">{{ t('easytier.installMethodNative') }}</ElRadio>
             <ElRadio label="official">{{ t('easytier.installMethodOfficial') }}</ElRadio>
           </ElRadioGroup>
         </ElFormItem>
 
-        <template v-if="serviceInstallForm.installMethod === 'nssm'">
-          <ElFormItem label="运行用户">
+        <template v-if="serviceInstallForm.installMethod === 'native'">
+          <ElFormItem label="运行用户" v-if="easyTierStore.os === 'windows'">
             <ElInput
               v-model="serviceInstallForm.username"
               placeholder="留空使用 LocalSystem（管理员权限）"
@@ -1000,7 +985,10 @@ onMounted(async () => {
             </template>
           </ElFormItem>
 
-          <ElFormItem label="用户密码" v-if="serviceInstallForm.username">
+          <ElFormItem
+            label="用户密码"
+            v-if="easyTierStore.os === 'windows' && serviceInstallForm.username"
+          >
             <ElInput
               v-model="serviceInstallForm.password"
               type="password"

--- a/src/views/config/index.vue
+++ b/src/views/config/index.vue
@@ -9,6 +9,7 @@ import { useEasyTierStore } from '@/store/modules/easytier'
 import type { EasyTierFormData } from '@/types/formTypes'
 import {
   deleteFileOrDir,
+  getDataDir,
   getLogsDir,
   listTomlFiles,
   readFileContent,
@@ -34,7 +35,7 @@ import {
   saveServiceInstallConfig
 } from '@/utils/serviceConfigUtil'
 import { getCurrentUsername, getHostname, getOsType, sleep } from '@/utils/sysUtil'
-import { join, resourceDir } from '@tauri-apps/api/path'
+import { join } from '@tauri-apps/api/path'
 import { attachConsole, error, info } from '@tauri-apps/plugin-log'
 import { ElMessageBox, ElNotification } from 'element-plus'
 import { cloneDeep } from 'lodash-es'
@@ -328,7 +329,7 @@ const addConfigAction = async () => {
   await getConfigList()
 }
 const saveConfigAction = async () => {
-  const resourceDirPath = await resourceDir()
+  const dataDirPath = getDataDir()
   if (editType.value === 'form') {
     // 验证必填 formRef
     if (!(await formRef.value.validateForm())) {
@@ -340,7 +341,7 @@ const saveConfigAction = async () => {
         // formData.value.file_logger.dir = formData.value.file_logger.dir
         //   ? formData.value.file_logger.dir
         //   : logsDir.value
-        formData.value.file_logger.dir = await join(resourceDirPath, LOG_PATH)
+        formData.value.file_logger.dir = await join(dataDirPath, LOG_PATH)
         formData.value.file_logger.file = configFileName.value
         if (
           !formData.value.proxy_network ||
@@ -432,7 +433,7 @@ const saveConfigAction = async () => {
         ...parseValue,
         file_logger: {
           level: parseValue.file_logger?.level ? parseValue.file_logger?.level : 'error',
-          dir: await join(resourceDirPath, LOG_PATH),
+          dir: await join(dataDirPath, LOG_PATH),
           file: configFileName.value
         }
       }
@@ -535,7 +536,7 @@ const confirmInstallService = async () => {
   // 保存配置
   saveServiceInstallConfig(row.configFileName, serviceInstallForm.value)
 
-  const configPath = await join(await resourceDir(), CONFIG_PATH, row.fileName)
+  const configPath = await join(getDataDir(), CONFIG_PATH, row.fileName)
   const serviceName = PREFIX_SVC + row.configFileName
 
   let result = false

--- a/src/views/index/index.vue
+++ b/src/views/index/index.vue
@@ -10,7 +10,7 @@ import { useTrayStore } from '@/store/modules/trayStore'
 import { extractAllPublicIPs, readTextReverse } from '@/utils/easyTierUtil'
 import { clearETLogs, listTomlFiles, readFileContent } from '@/utils/fileUtil'
 import {
-  checkRouteOnWindows,
+  checkRoute,
   executeCmd,
   getRunningProcesses,
   killProcess,
@@ -18,7 +18,7 @@ import {
   runEasyTierCore,
   safeJsonParse
 } from '@/utils/shellUtil'
-import { notify, sleep } from '@/utils/sysUtil'
+import { getPlatform, notify, sleep } from '@/utils/sysUtil'
 import { ArrowDown, CopyDocument, Link, Monitor, Platform, Setting } from '@element-plus/icons-vue'
 import { invoke } from '@tauri-apps/api/core'
 import { attachConsole, error, info } from '@tauri-apps/plugin-log'
@@ -126,15 +126,31 @@ watch(
 )
 const getActiveNetworkAdapter = async () => {
   try {
-    const res = await executeCmd(
-      'powershell',
-      [
-        '-NoProfile',
-        '-Command',
-        'Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null -and $_.NetAdapter.Status -eq "Up" -and $_.NetAdapter.Name -notlike "et*" -and $_.NetAdapter.Name -notlike "easytier*"} | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty NetAdapter | Select-Object -ExpandProperty Name'
-      ],
-      { encoding: 'gbk' }
-    )
+    const platform = await getPlatform()
+    let res: string | boolean
+    if (platform === 'windows') {
+      res = await executeCmd(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          'Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null -and $_.NetAdapter.Status -eq "Up" -and $_.NetAdapter.Name -notlike "et*" -and $_.NetAdapter.Name -notlike "easytier*"} | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty NetAdapter | Select-Object -ExpandProperty Name'
+        ],
+        { encoding: 'gbk' }
+      )
+    } else if (platform === 'linux') {
+      // Get the interface used for default route, excluding easytier interfaces
+      res = await executeCmd('sh', [
+        '-c',
+        'ip route get 1.1.1.1 2>/dev/null | head -1 | awk \'{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}\''
+      ])
+    } else {
+      // macOS
+      res = await executeCmd('sh', [
+        '-c',
+        "route -n get default 2>/dev/null | awk '/interface:/{print $2}'"
+      ])
+    }
     const adapterName = typeof res === 'string' ? res.trim() : ''
     return adapterName || null
   } catch (e) {
@@ -145,15 +161,33 @@ const getActiveNetworkAdapter = async () => {
 
 const disableAutoMetric = async (adapterName: string) => {
   try {
-    await executeCmd(
-      'powershell',
-      [
-        '-NoProfile',
-        '-Command',
-        `Set-NetIPInterface -InterfaceAlias "${adapterName}" -AutomaticMetric Disabled -InterfaceMetric 1`
-      ],
-      { encoding: 'gbk' }
-    )
+    const platform = await getPlatform()
+    if (platform === 'windows') {
+      await executeCmd(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          `Set-NetIPInterface -InterfaceAlias "${adapterName}" -AutomaticMetric Disabled -InterfaceMetric 1`
+        ],
+        { encoding: 'gbk' }
+      )
+    } else if (platform === 'linux') {
+      // Lower the metric on the default route via this interface
+      await executeCmd('sudo', [
+        'ip',
+        'route',
+        'change',
+        'default',
+        'dev',
+        adapterName,
+        'metric',
+        '1'
+      ])
+    } else {
+      // macOS: change default route metric
+      await executeCmd('sudo', ['route', 'change', 'default', '-interface', adapterName])
+    }
     return true
   } catch (e) {
     error(`关闭网卡自动跃点失败:${String(e)}`)
@@ -163,15 +197,33 @@ const disableAutoMetric = async (adapterName: string) => {
 
 const enableAutoMetric = async (adapterName: string) => {
   try {
-    await executeCmd(
-      'powershell',
-      [
-        '-NoProfile',
-        '-Command',
-        `Set-NetIPInterface -InterfaceAlias "${adapterName}" -AutomaticMetric Enabled`
-      ],
-      { encoding: 'gbk' }
-    )
+    const platform = await getPlatform()
+    if (platform === 'windows') {
+      await executeCmd(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          `Set-NetIPInterface -InterfaceAlias "${adapterName}" -AutomaticMetric Enabled`
+        ],
+        { encoding: 'gbk' }
+      )
+    } else if (platform === 'linux') {
+      // Restore default metric on the interface
+      await executeCmd('sudo', [
+        'ip',
+        'route',
+        'change',
+        'default',
+        'dev',
+        adapterName,
+        'metric',
+        '100'
+      ])
+    } else {
+      // macOS: restore default route
+      await executeCmd('sudo', ['route', 'change', 'default', '-interface', adapterName])
+    }
     return true
   } catch (e) {
     error(`开启网卡自动跃点失败:${String(e)}`)
@@ -215,12 +267,26 @@ const setExitRoute = async (val) => {
 
   const getDefaultGateway = async () => {
     try {
-      const res = await executeCmd('powershell', [
-        '-NoProfile',
-        '-Command',
-        // '(Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null -and $_.NetAdapter.Status -ne "Disconnected"} | Select-Object -First 1 -ExpandProperty IPv4DefaultGateway).NextHop'
-        'Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null -and $_.NetAdapter.Status -eq "Up" -and $_.NetAdapter.Name -notlike "et*" -and $_.NetAdapter.Name -notlike "easytier*"} | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IPv4DefaultGateway | Select-Object -ExpandProperty NextHop'
-      ])
+      const platform = await getPlatform()
+      let res: string | boolean
+      if (platform === 'windows') {
+        res = await executeCmd('powershell', [
+          '-NoProfile',
+          '-Command',
+          'Get-NetIPConfiguration | Where-Object {$_.IPv4DefaultGateway -ne $null -and $_.NetAdapter.Status -eq "Up" -and $_.NetAdapter.Name -notlike "et*" -and $_.NetAdapter.Name -notlike "easytier*"} | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IPv4DefaultGateway | Select-Object -ExpandProperty NextHop'
+        ])
+      } else if (platform === 'linux') {
+        res = await executeCmd('sh', [
+          '-c',
+          "ip route | grep '^default' | grep -v 'easytier\\|et_' | head -1 | awk '{print $3}'"
+        ])
+      } else {
+        // macOS
+        res = await executeCmd('sh', [
+          '-c',
+          "route -n get default 2>/dev/null | awk '/gateway:/{print $2}'"
+        ])
+      }
       const match = typeof res === 'string' ? res.match(/\d+\.\d+\.\d+\.\d+/) : null
       return match ? match[0] : null
     } catch (e) {
@@ -250,8 +316,42 @@ const setExitRoute = async (val) => {
     gateway: string,
     metric: number
   ) => {
-    const args = [method, target, 'mask', mask, gateway, 'metric', String(metric)]
-    await executeCmd('route', args, { encoding: 'gbk' })
+    const platform = await getPlatform()
+    if (platform === 'windows') {
+      const args = [method, target, 'mask', mask, gateway, 'metric', String(metric)]
+      await executeCmd('route', args, { encoding: 'gbk' })
+    } else if (platform === 'linux') {
+      if (method === 'add') {
+        await executeCmd('sudo', [
+          'ip',
+          'route',
+          'add',
+          `${target}/${mask}`,
+          'via',
+          gateway,
+          'metric',
+          String(metric)
+        ])
+      } else if (method === 'change') {
+        await executeCmd('sudo', [
+          'ip',
+          'route',
+          'replace',
+          `${target}/${mask}`,
+          'via',
+          gateway,
+          'metric',
+          String(metric)
+        ])
+      }
+    } else {
+      // macOS
+      if (method === 'add') {
+        await executeCmd('sudo', ['route', '-n', 'add', '-net', `${target}/${mask}`, gateway])
+      } else if (method === 'change') {
+        await executeCmd('sudo', ['route', '-n', 'change', '-net', `${target}/${mask}`, gateway])
+      }
+    }
   }
 
   if (val && parseValue.config_exit_nodes_route && parseValue.exit_nodes.length > 0) {
@@ -280,13 +380,7 @@ const setExitRoute = async (val) => {
 
       const canSet = Boolean(exitNodeIp && gateway && publicIps?.length && waitHole === true)
 
-      if (
-        canSet &&
-        exitNodeIp &&
-        gateway &&
-        publicIps &&
-        (await checkRouteOnWindows(localNode.ipv4))
-      ) {
+      if (canSet && exitNodeIp && gateway && publicIps && (await checkRoute(localNode.ipv4))) {
         await addRouteSeq('change', '0.0.0.0', '0.0.0.0', gateway, 30)
         // 按顺序依次添加路由，之间不跳过
         for (const publicIp of publicIps) {
@@ -307,26 +401,51 @@ const runningTag = computed(() => {
 })
 const handlePing = async (ip: string) => {
   if (!ip || ip === '服务器') return
-  // Windows: cmd /k ping <ip>
-  await Command.create('cmd', ['/c', 'start', 'cmd', '/k', `ping ${ip}`]).spawn()
+  const platform = await getPlatform()
+  if (platform === 'windows') {
+    await Command.create('cmd', ['/c', 'start', 'cmd', '/k', `ping ${ip}`]).spawn()
+  } else if (platform === 'linux') {
+    await Command.create('sh', ['-c', `xterm -e "ping ${ip}" &`]).spawn()
+  } else {
+    await Command.create('open', ['-a', 'Terminal', `ping ${ip}`]).spawn()
+  }
 }
 
 const handleRDP = async (ip: string) => {
   if (!ip) return
-  // mstsc /v:<ip>
-  await Command.create('mstsc', [`/v:${ip}`]).spawn()
+  const platform = await getPlatform()
+  if (platform === 'windows') {
+    await Command.create('mstsc', [`/v:${ip}`]).spawn()
+  } else if (platform === 'linux') {
+    await Command.create('xfreerdp', [`/v:${ip}`]).spawn()
+  } else {
+    // macOS has built-in RDP via URL scheme
+    await Command.create('open', [`rdp://full%20address=s:${ip}`]).spawn()
+  }
 }
 
 const handleTelnet = async (ip: string) => {
   if (!ip || ip === '服务器') return
-  // Windows: cmd /k telnet <ip>
-  await Command.create('cmd', ['/c', 'start', 'cmd', '/k', `telnet ${ip}`]).spawn()
+  const platform = await getPlatform()
+  if (platform === 'windows') {
+    await Command.create('cmd', ['/c', 'start', 'cmd', '/k', `telnet ${ip}`]).spawn()
+  } else if (platform === 'linux') {
+    await Command.create('sh', ['-c', `xterm -e "telnet ${ip}" &`]).spawn()
+  } else {
+    await Command.create('open', ['-a', 'Terminal', `telnet ${ip}`]).spawn()
+  }
 }
 
 const handleSSH = async (ip: string) => {
   if (!ip || ip === '服务器') return
-  // Windows: cmd /k ssh root@<ip>
-  await Command.create('cmd', ['/c', 'start', 'cmd', '/k', `ssh root@${ip}`]).spawn()
+  const platform = await getPlatform()
+  if (platform === 'windows') {
+    await Command.create('cmd', ['/c', 'start', 'cmd', '/k', `ssh root@${ip}`]).spawn()
+  } else if (platform === 'linux') {
+    await Command.create('sh', ['-c', `xterm -e "ssh root@${ip}" &`]).spawn()
+  } else {
+    await Command.create('open', ['-a', 'Terminal', `ssh root@${ip}`]).spawn()
+  }
 }
 
 const handleXshell = async (ip: string) => {
@@ -1060,7 +1179,7 @@ onMounted(async () => {
                     <el-icon>
                       <Link />
                     </el-icon>
-                    Windows SSH
+                    SSH
                   </el-dropdown-item>
                   <el-dropdown-item :command="handleRDP">
                     <el-icon>
@@ -1068,7 +1187,7 @@ onMounted(async () => {
                     </el-icon>
                     远程桌面 (RDP)
                   </el-dropdown-item>
-                  <el-dropdown-item :command="handleXshell">
+                  <el-dropdown-item v-if="easyTierStore.os === 'windows'" :command="handleXshell">
                     <el-icon>
                       <Link />
                     </el-icon>

--- a/src/views/setting/index.vue
+++ b/src/views/setting/index.vue
@@ -18,6 +18,7 @@ import { useEasyTierStore } from '@/store/modules/easytier'
 import {
   downloadFile,
   extractFile,
+  getDataDir,
   getLogsDir,
   getResourceDir,
   listTomlFiles,
@@ -25,7 +26,7 @@ import {
 } from '@/utils/fileUtil'
 import { runEasyTierCli, stopAllNodes } from '@/utils/shellUtil'
 import { getAppVersion, getArch, getOsType } from '@/utils/sysUtil'
-import { appDataDir, appLogDir, join, resourceDir } from '@tauri-apps/api/path'
+import { appDataDir, appLogDir, join } from '@tauri-apps/api/path'
 import { fetch } from '@tauri-apps/plugin-http'
 import { useClipboard } from '@vueuse/core'
 import {
@@ -259,11 +260,11 @@ const checkCorePath = async () => {
   }
 }
 const openConfigPath = async () => {
-  const configPath = await join(await resourceDir(), 'config')
+  const configPath = await join(getDataDir(), 'config')
   await openPath(configPath)
 }
 const openCorePath = async () => {
-  const resourcePath = await join(await resourceDir(), RESOURCE_PATH)
+  const resourcePath = await join(getDataDir(), RESOURCE_PATH)
   await openPath(resourcePath)
 }
 // @ts-ignore
@@ -271,7 +272,7 @@ const openCorePath = async () => {
 const copyLogPath = async () => {
   // 拷贝
   const { copy, copied, isSupported } = useClipboard({
-    source: await join(await resourceDir(), LOG_PATH),
+    source: await join(getDataDir(), LOG_PATH),
     legacy: true
   })
   if (!isSupported) {
@@ -284,7 +285,7 @@ const copyLogPath = async () => {
   }
 }
 const openLogPath = async () => {
-  const resourcePath = await join(await resourceDir(), LOG_PATH)
+  const resourcePath = await join(getDataDir(), LOG_PATH)
   await openPath(resourcePath)
 }
 // const openLogPath2 = async () => {

--- a/src/views/setting/index.vue
+++ b/src/views/setting/index.vue
@@ -50,7 +50,7 @@ const p2pNotify = ref(true)
 const refreshInterval = ref(3)
 const xshellPath = ref('')
 const lockPassword = ref('')
-const defaultServiceInstallMethod = ref<'nssm' | 'official'>('nssm')
+const defaultServiceInstallMethod = ref<'native' | 'official'>('native')
 const defaultEnableAutostart = ref(true)
 
 const handleMinimizeChange = (value: boolean) => {
@@ -82,7 +82,7 @@ const saveLockPassword = () => {
   ElMessage.success('锁定密码已保存')
 }
 
-const handleServiceInstallMethodChange = (value: 'nssm' | 'official') => {
+const handleServiceInstallMethodChange = (value: 'native' | 'official') => {
   easyTierStore.setDefaultServiceInstallMethod(value)
 }
 
@@ -599,7 +599,7 @@ onMounted(async () => {
               >工作台节点列表刷新间隔（秒），最低2秒</span
             >
           </el-form-item>
-          <el-form-item label="Xshell 路径">
+          <el-form-item v-if="easyTierStore.os === 'windows'" label="Xshell 路径">
             <el-input
               v-model="xshellPath"
               placeholder="例如: C:\Program Files (x86)\NetSarang\Xshell 7\Xshell.exe"
@@ -640,7 +640,16 @@ onMounted(async () => {
                   style="width: 280px"
                   @change="handleServiceInstallMethodChange"
                 >
-                  <el-option label="NSSM (推荐，兼容性好)" value="nssm" />
+                  <el-option
+                    :label="
+                      easyTierStore.os === 'windows'
+                        ? 'NSSM (推荐，兼容性好)'
+                        : easyTierStore.os === 'linux'
+                          ? 'systemd (推荐)'
+                          : 'launchd (推荐)'
+                    "
+                    value="native"
+                  />
                   <el-option label="官方 easytier-cli (v1.2.0+)" value="official" />
                 </el-select>
                 <span class="ml-10px text-12px text-[var(--el-text-color-secondary)]"


### PR DESCRIPTION
Fix #21, Fix #39 

当前分支可以保证编译通过，不过软件打开是白屏，还需要进一步修复。当前分支是 cherry pick 出来方便 PR 合并的，依赖 #43 ，我个人的完整开发分支在 [rabit-dev](https://github.com/ttimasdf/easytier-manager/tree/rabit-dev)

- Use conditional compilation for Windows-specific CommandExt trait
- Provide Linux-compatible version without creation_flags
- Fix child.id() to use expect() for better error handling

